### PR TITLE
Set default speed to 10x

### DIFF
--- a/animation.js
+++ b/animation.js
@@ -82,6 +82,7 @@ window.addEventListener('load', () => {
         return;
     }
     console.log('Speed controls found');
+    speedValue.textContent = `${speedMultiplier}x`;
 
     // Set canvas size based on its display size
     function resizeCanvas() {
@@ -98,7 +99,7 @@ window.addEventListener('load', () => {
     window.addEventListener('resize', resizeCanvas);
 
     // Global speed multiplier
-    let speedMultiplier = 12;
+    let speedMultiplier = 10;
 
     // Add rate limiting variables at the top level
     let lastPunTime = 0;
@@ -226,6 +227,7 @@ window.addEventListener('load', () => {
         new Ball(250, 450, 20, '#FF6347')     // Tomato
     ];
     console.log('Balls created:', balls.length);
+    balls.forEach(ball => ball.updateSpeed());
 
     // Speed control event listener
     speedSlider.addEventListener('input', async (e) => {


### PR DESCRIPTION
## Summary
- default `speedMultiplier` to 10
- update `.speed-value` on page load
- apply the multiplier to initial ball speeds

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6843a9a451cc832b9089e46f0bf35afc